### PR TITLE
Alternate download method to work around "Freeleech filter disabled"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 *A Freeleech Torrent Grabber for What.CD*
 ---
 
-Requires python2.7 + pip + `$ pip install requests HTMLParser`
+Requires python2.7 + pip + `$ pip install requests HTMLParser BeautifulSoup`
 
 Usage: `python yoink.py [option]`
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 *A Freeleech Torrent Grabber for What.CD*
 ---
 
-Requires python2.7 + pip + `$ pip install requests HTMLParser BeautifulSoup`
+Requires python2.7 + pip + `$ pip install requests HTMLParser BeautifulSoup4`
 
 Usage: `python yoink.py [option]`
 

--- a/yoink.py
+++ b/yoink.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import time
+import time, datetime
 import cPickle as pickle
 import json
 import requests
@@ -10,6 +10,8 @@ import re
 import sys
 import argparse
 import sqlite3
+import cgi
+from bs4 import BeautifulSoup
 from os.path import expanduser
 
 ## SAFE TO EDIT ##
@@ -296,8 +298,6 @@ def main():
   def altDownloadMethod(session):
     continueLeeching = True
     page = 1
-    from bs4 import BeautifulSoup
-    import cgi, code, datetime
     while continueLeeching:
       r = session.get("https://what.cd/torrents.php?search=&freetorrent=1" + search_params + "&page={}".format(page), headers=headers)
       document = BeautifulSoup(r.text)


### PR DESCRIPTION
I've created an alternate download method that scrapes https://what.cd/torrents.php?search=&freetorrent=1 for urls using BeautifulSoup to download freeleech torrents. The alternate download method will be attempted if the API returns "Freeleech filter disabled" when trying to download normally.